### PR TITLE
Add BigQuery integration to news feed parser

### DIFF
--- a/feedparser_news.py
+++ b/feedparser_news.py
@@ -1,21 +1,72 @@
+"""Download news from an RSS feed and store them in BigQuery.
+
+This script parses an RSS feed using ``feedparser`` and writes the
+resulting entries to a BigQuery table.  Each row in the table contains the
+title, description, link, published date and summary of a news item.
+"""
+
+from __future__ import annotations
+
 import feedparser
+from google.cloud import bigquery
 
-# Replace with the actual URL of the RSS feed you want to parse
-feed_url = "https://news.google.com/rss/search?q=entregadores&hl=pt-BR&gl=BR&ceid=BR:pt-419" 
 
-# Parse the RSS feed
-feed = feedparser.parse(feed_url)
+def extract_news(feed_url: str) -> list[dict[str, str]]:
+    """Fetch news entries from ``feed_url``.
 
-# Accessing feed metadata (e.g., title, description, link)
-print("Feed Title:", feed.feed.title)
-print("Feed Description:", feed.feed.description)
-print("Feed Link:", feed.feed.link)
+    Parameters
+    ----------
+    feed_url:
+        The URL of the RSS feed to parse.
 
-# Iterating through feed entries (articles or items)
-print("\nEntries:")
-for entry in feed.entries:
-    print("  Title:", entry.title)
-    print("  Link:", entry.link)
-    print("  Published Date:", entry.published)
-    print("  Summary:", entry.summary)
-    print("-" * 20)
+    Returns
+    -------
+    list of dict
+        A list where each element contains the keys ``title``,
+        ``description``, ``link``, ``published`` and ``summary``.
+    """
+
+    feed = feedparser.parse(feed_url)
+    news_items: list[dict[str, str]] = []
+
+    for entry in feed.entries:
+        news_items.append(
+            {
+                "title": entry.title,
+                "description": getattr(entry, "description", ""),
+                "link": entry.link,
+                "published": getattr(entry, "published", ""),
+                "summary": getattr(entry, "summary", ""),
+            }
+        )
+
+    return news_items
+
+
+def main() -> None:
+    # Replace with the actual URL of the RSS feed you want to parse
+    feed_url = (
+        "https://news.google.com/rss/search?q=entregadores&hl=pt-BR&gl=BR&ceid=BR:pt-419"
+    )
+
+    # Replace with your project, dataset and table path
+    table_id = "your-project.your_dataset.your_table"
+
+    client = bigquery.Client()
+    news_items = extract_news(feed_url)
+
+    rows_added = 0
+    for item in news_items:
+        errors = client.insert_rows_json(table_id, [item])
+        if errors:
+            print(f"Failed to add row for '{item['title']}': {errors}")
+        else:
+            rows_added += 1
+            print(f"Added row {rows_added}: {item['title']}")
+
+    print(f"Total rows added: {rows_added}")
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- fetch news entries via new `extract_news` function
- insert RSS feed items into a BigQuery table and log progress

## Testing
- `python feedparser_news.py` *(fails: ModuleNotFoundError: No module named 'feedparser')*
- `pip install feedparser google-cloud-bigquery` *(fails: Could not find a version that satisfies the requirement feedparser)*

------
https://chatgpt.com/codex/tasks/task_e_68a20cb34e5c832ea9df64f3c9d8320f